### PR TITLE
Fix compile error in newer GCC

### DIFF
--- a/deps/jscshim/include/v8.h
+++ b/deps/jscshim/include/v8.h
@@ -629,7 +629,7 @@ public:
 
 	V8_WARN_UNUSED_RESULT MaybeLocal<Value> StackTrace(Local<Context> context) const;
 
-	Local<Message> Message() const;
+	Local<v8::Message> Message() const;
 
 	void Reset();
 

--- a/deps/jscshim/src/base/logging.cc
+++ b/deps/jscshim/src/base/logging.cc
@@ -9,6 +9,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <wtf/ASCIICType.h>
 
 #include "src/base/platform/platform.h"
 
@@ -42,7 +43,7 @@ void PrettyPrintChar(std::ostream& os, int ch) {
     CHAR_PRINT_CASE('\v')
 #undef CHAR_PRINT_CASE
     default:
-      if (std::isprint(ch)) {
+      if (::WTF::isASCIIPrintable(ch)) {
         os << '\'' << ch << '\'';
       } else {
         auto flags = os.flags(std::ios_base::hex);

--- a/deps/jscshim/src/inspector/string-16.cc
+++ b/deps/jscshim/src/inspector/string-16.cc
@@ -21,7 +21,7 @@
 #include <unicode/umachine.h>
 
 namespace WTF {
-  template<> struct WTF::IntegerToStringConversionTrait<v8_inspector::String16> {
+  template<> struct IntegerToStringConversionTrait<v8_inspector::String16> {
     using ReturnType = v8_inspector::String16;
     using AdditionalArgumentType = void;
     static v8_inspector::String16 flush(LChar* characters, unsigned length, void*) { return { (char *)characters, length }; }


### PR DESCRIPTION
This patch fixes compile errors in the newer GCC (8.2.0).