### PR TITLE
Use "webkit" instead of "WebKit" for directory name

### DIFF
--- a/deps/jscshim/tools/build_jsc.py
+++ b/deps/jscshim/tools/build_jsc.py
@@ -200,7 +200,7 @@ def build_jsc(options):
 	# The build scripts use paths relative to WebKit's root the (the update scripts at least)
 	# Note that this must be done right before running WebKit's script, as the above create_icu_header_paths
 	# uses os.path.abspath, and relies on node's root dir to be the current dir.
-	os.chdir('WebKit')
+	os.chdir('webkit')
 
 	#for env_var in ENV_VARS_TO_DELETE:
 	#	del os.environ[env_var]

--- a/deps/jscshim/webkit.gyp
+++ b/deps/jscshim/webkit.gyp
@@ -38,7 +38,7 @@
       'include_dirs': [
         '<(webkit_output_dir)/DerivedSources/ForwardingHeaders',
         '<(webkit_output_dir)/DerivedSources/ForwardingHeaders/JavaScriptCore',
-        './WebKit/Source/bmalloc',
+        './webkit/Source/bmalloc',
 
         # For cmakeconfig.h
         '<(webkit_output_dir)',
@@ -133,8 +133,8 @@
         'tools/build_jsc.py',
 
         # Use the ChangeLogs as inputs since they change when WebKit updates, which will trigger this action
-        'WebKit/Source/JavaScriptCore/ChangeLog',
-        'WebKit/Source/WTF/ChangeLog'
+        'webkit/Source/JavaScriptCore/ChangeLog',
+        'webkit/Source/WTF/ChangeLog'
       ],
       'outputs': ['<@(webkit_output_libraries)'],
       'action': ['python', 'tools/build_jsc.py', '<@(build_jsc_args)']


### PR DESCRIPTION
Many Linux FSes are case sensitive for path names. Use "webkit" instead of "WebKit"
since the actual directory name is "webkit".