### PR TITLE
Link dl library required by bmalloc in Linux

### DIFF
--- a/deps/jscshim/jscshim.gyp
+++ b/deps/jscshim/jscshim.gyp
@@ -113,6 +113,9 @@
       }],
       ['OS in "linux"', {
         'cflags_cc': [ '-fexceptions' ],
+        'link_settings': {
+          'libraries': [ '-ldl' ],
+        },
       }],
       ['OS in "mac ios"', {
         'cflags_cc': [ '-fexceptions' ],
@@ -350,6 +353,9 @@
       }],
       ['OS in "linux"', {
         'cflags_cc': [ '-fexceptions' ],
+        'link_settings': {
+          'libraries': [ '-ldl' ],
+        },
       }],
       ['OS in "mac ios"', {
         'cflags_cc': [ '-fexceptions' ],


### PR DESCRIPTION
libdl is required since we use dlopen etc. to check ASAN condition in Linux.