### PR TITLE
Implement initial Isolate::EnqueueMicrotask support

### DIFF
--- a/deps/jscshim/test/src/test-api.cc
+++ b/deps/jscshim/test/src/test-api.cc
@@ -21872,47 +21872,47 @@ THREADED_TEST(CallAPIFunctionOnNonObject) {
 //  CHECK_EQ(3, CompileRun("ext2Calls")->Int32Value(env.local()).FromJust());
 //  g_passed_to_three = nullptr;
 //}
-//
-//
-//static void MicrotaskExceptionOne(
-//    const v8::FunctionCallbackInfo<Value>& info) {
-//  v8::HandleScope scope(info.GetIsolate());
-//  CompileRun("exception1Calls++;");
-//  info.GetIsolate()->ThrowException(
-//      v8::Exception::Error(v8_str("first")));
-//}
-//
-//
-//static void MicrotaskExceptionTwo(
-//    const v8::FunctionCallbackInfo<Value>& info) {
-//  v8::HandleScope scope(info.GetIsolate());
-//  CompileRun("exception2Calls++;");
-//  info.GetIsolate()->ThrowException(
-//      v8::Exception::Error(v8_str("second")));
-//}
-//
-//
-//TEST(RunMicrotasksIgnoresThrownExceptions) {
-//  LocalContext env;
-//  v8::Isolate* isolate = env->GetIsolate();
-//  v8::HandleScope scope(isolate);
-//  CompileRun(
-//      "var exception1Calls = 0;"
-//      "var exception2Calls = 0;");
-//  isolate->EnqueueMicrotask(
-//      Function::New(env.local(), MicrotaskExceptionOne).ToLocalChecked());
-//  isolate->EnqueueMicrotask(
-//      Function::New(env.local(), MicrotaskExceptionTwo).ToLocalChecked());
-//  TryCatch try_catch(isolate);
-//  CompileRun("1+1;");
-//  CHECK(!try_catch.HasCaught());
-//  CHECK_EQ(1,
-//           CompileRun("exception1Calls")->Int32Value(env.local()).FromJust());
-//  CHECK_EQ(1,
-//           CompileRun("exception2Calls")->Int32Value(env.local()).FromJust());
-//}
-//
-//
+
+
+static void MicrotaskExceptionOne(
+   const v8::FunctionCallbackInfo<Value>& info) {
+ v8::HandleScope scope(info.GetIsolate());
+ CompileRun("exception1Calls++;");
+ info.GetIsolate()->ThrowException(
+     v8::Exception::Error(v8_str("first")));
+}
+
+
+static void MicrotaskExceptionTwo(
+   const v8::FunctionCallbackInfo<Value>& info) {
+ v8::HandleScope scope(info.GetIsolate());
+ CompileRun("exception2Calls++;");
+ info.GetIsolate()->ThrowException(
+     v8::Exception::Error(v8_str("second")));
+}
+
+
+TEST(RunMicrotasksIgnoresThrownExceptions) {
+ LocalContext env;
+ v8::Isolate* isolate = env->GetIsolate();
+ v8::HandleScope scope(isolate);
+ CompileRun(
+     "var exception1Calls = 0;"
+     "var exception2Calls = 0;");
+ isolate->EnqueueMicrotask(
+     Function::New(env.local(), MicrotaskExceptionOne).ToLocalChecked());
+ isolate->EnqueueMicrotask(
+     Function::New(env.local(), MicrotaskExceptionTwo).ToLocalChecked());
+ TryCatch try_catch(isolate);
+ CompileRun("1+1;");
+ CHECK(!try_catch.HasCaught());
+ CHECK_EQ(1,
+          CompileRun("exception1Calls")->Int32Value(env.local()).FromJust());
+ CHECK_EQ(1,
+          CompileRun("exception2Calls")->Int32Value(env.local()).FromJust());
+}
+
+
 //uint8_t microtasks_completed_callback_count = 0;
 //
 //


### PR DESCRIPTION
This patch implements v8::Isolate::EnqueueMicrotask, which puts a microtask into
the JSC's microtask queue.