### PR TITLE
Add GetScriptNameOrSourceURL support

### DIFF
--- a/deps/jscshim/include/v8.h
+++ b/deps/jscshim/include/v8.h
@@ -700,6 +700,8 @@ public:
 
 	Local<String> GetScriptName() const;
 
+	Local<String> GetScriptNameOrSourceURL() const;
+
 	Local<String> GetFunctionName() const;
 
 	bool IsEval() const;

--- a/deps/jscshim/src/shim/CallSitePrototype.cpp
+++ b/deps/jscshim/src/shim/CallSitePrototype.cpp
@@ -55,6 +55,7 @@ static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetFileName(JSC::ExecS
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetLineNumber(JSC::ExecState * exec);
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetColumnNumber(JSC::ExecState * exec);
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetEvalOrigin(JSC::ExecState * exec);
+static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetScriptNameOrSourceURL(JSC::ExecState * exec);
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncIsToplevel(JSC::ExecState * exec);
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncIsEval(JSC::ExecState * exec);
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncIsNative(JSC::ExecState * exec);
@@ -80,6 +81,7 @@ void CallSitePrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject * global
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("getLineNumber", callSiteProtoFuncGetLineNumber, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("getColumnNumber", callSiteProtoFuncGetColumnNumber, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("getEvalOrigin", callSiteProtoFuncGetEvalOrigin, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
+	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("getScriptNameOrSourceURL", callSiteProtoFuncGetScriptNameOrSourceURL, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("isToplevel", callSiteProtoFuncIsToplevel, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("isEval", callSiteProtoFuncIsEval, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
 	JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("isNative", callSiteProtoFuncIsNative, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, JSC::NoIntrinsic);
@@ -138,6 +140,13 @@ static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetColumnNumber(JSC::E
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetEvalOrigin(JSC::ExecState * exec)
 {
 	return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+
+static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncGetScriptNameOrSourceURL(JSC::ExecState * exec)
+{
+	ENTER_PROTO_FUNC();
+	return JSC::JSValue::encode(callSite->sourceURL());
 }
 
 static JSC::EncodedJSValue JSC_HOST_CALL callSiteProtoFuncIsToplevel(JSC::ExecState * exec)

--- a/deps/jscshim/src/v8StackTrace.cpp
+++ b/deps/jscshim/src/v8StackTrace.cpp
@@ -65,6 +65,11 @@ Local<String> StackFrame::GetScriptName() const
 	return Local<String>::New(JSC::JSValue(GET_JSC_THIS_STACK_FRAME()->scriptName()));
 }
 
+Local<String> StackFrame::GetScriptNameOrSourceURL() const
+{
+	return Local<String>::New(JSC::JSValue(GET_JSC_THIS_STACK_FRAME()->scriptName()));
+}
+
 Local<String> StackFrame::GetFunctionName() const
 {
 	return Local<String>::New(JSC::JSValue(GET_JSC_THIS_STACK_FRAME()->functionName()));


### PR DESCRIPTION
We found that CallSite#getScriptNameOrSourceURL support is critical if we would like to run web-tooling-benchmark[1] in the node shell.
This patch adds CallSite#getScriptNameOrSourceURL and v8::StrackFrame::GetScriptNameOrSourceURL support. They just return source URL for now.

[1]: https://github.com/v8/web-tooling-benchmark