### PR TITLE
Initial GC stabilizing patch

### DIFF
--- a/deps/jscshim/src/shim/APIAccessor.cpp
+++ b/deps/jscshim/src/shim/APIAccessor.cpp
@@ -33,7 +33,7 @@ void APIAccessor::visitChildren(JSC::JSCell * cell, JSC::SlotVisitor& visitor)
 	APIAccessor * thisObject = JSC::jsCast<APIAccessor *>(cell);
 	visitor.append(thisObject->m_name);
 	visitor.append(thisObject->m_data);
-	visitor.appendUnbarriered(thisObject->m_signature.get());
+	visitor.append(thisObject->m_signature);
 }
 
 /* TODO: Should we call Isolate::HandleThrownException in getter\setter? If we're being called from JS, 

--- a/deps/jscshim/src/shim/CallSite.cpp
+++ b/deps/jscshim/src/shim/CallSite.cpp
@@ -65,8 +65,8 @@ void CallSite::finishCreation(JSC::ExecState * exec, JSCStackFrame& stackFrame, 
     const auto * sourcePositions = stackFrame.getSourcePositions();
     if (sourcePositions)
     {
-        m_lineNumber = JSC::jsNumber(sourcePositions->line.oneBasedInt());
-        m_columnNumber = JSC::jsNumber(sourcePositions->startColumn.oneBasedInt());
+        m_lineNumber = sourcePositions->line.oneBasedInt();
+        m_columnNumber = sourcePositions->startColumn.oneBasedInt();
     }
 
     if (stackFrame.isEval()) 

--- a/deps/jscshim/src/shim/CallSite.h
+++ b/deps/jscshim/src/shim/CallSite.h
@@ -27,8 +27,8 @@ private:
 	JSC::WriteBarrier<JSC::Unknown> m_function;
 	JSC::WriteBarrier<JSC::Unknown> m_functionName;
 	JSC::WriteBarrier<JSC::Unknown> m_sourceURL;
-	JSC::JSValue m_lineNumber;
-	JSC::JSValue m_columnNumber;
+	int m_lineNumber { -1 };
+	int m_columnNumber { -1 };
 	unsigned int m_flags;
 
 public:
@@ -53,8 +53,8 @@ public:
 	JSC::JSValue function() const { return m_function.get(); }
 	JSC::JSValue functionName() const { return m_functionName.get(); }
 	JSC::JSValue sourceURL() const { return m_sourceURL.get(); }
-	JSC::JSValue lineNumber() const { return m_lineNumber; }
-	JSC::JSValue columnNumber() const { return m_columnNumber; }
+	JSC::JSValue lineNumber() const { return JSC::jsNumber(m_lineNumber); }
+	JSC::JSValue columnNumber() const { return JSC::jsNumber(m_columnNumber); }
 	bool isEval() const { return m_flags & static_cast<unsigned int>(Flags::IsEval); }
 	bool isConstructor() const { return m_flags & static_cast<unsigned int>(Flags::IsConstructor); }
 	bool isStrict() const { return m_flags & static_cast<unsigned int>(Flags::IsStrict); }
@@ -62,9 +62,7 @@ public:
 private:
 	/* Note that v8's JSStackFrame::GetLineNumber & JSStackFrame::GetColumnNumber (messages.cc) fallback to -1, 
 	 * so we'll do the same */
-	CallSite(JSC::VM& vm, JSC::Structure * structure) : Base(vm, structure),
-		m_lineNumber(-1),
-		m_columnNumber(-1)
+	CallSite(JSC::VM& vm, JSC::Structure * structure) : Base(vm, structure)
 	{
 	}
 

--- a/deps/jscshim/src/shim/FunctionTemplate.cpp
+++ b/deps/jscshim/src/shim/FunctionTemplate.cpp
@@ -214,6 +214,7 @@ void FunctionTemplate::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visito
 	visitor.append(thisObject->m_prototypeProviderTemplate);
 	visitor.append(thisObject->m_prototypeTemplate);
 	visitor.append(thisObject->m_instanceTemplate);
+	visitor.append(thisObject->m_signature);
 	visitor.append(thisObject->m_templateClassName);
 }
 

--- a/deps/jscshim/src/shim/FunctionTemplate.cpp
+++ b/deps/jscshim/src/shim/FunctionTemplate.cpp
@@ -210,10 +210,10 @@ void FunctionTemplate::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visito
 	Base::visitChildren(cell, visitor);
 
 	FunctionTemplate * thisObject = JSC::jsCast<FunctionTemplate *>(cell);
-	visitor.appendUnbarriered(thisObject->m_parentTemplate.get());
-	visitor.appendUnbarriered(thisObject->m_prototypeProviderTemplate.get());
-	visitor.appendUnbarriered(thisObject->m_prototypeTemplate.get());
-	visitor.appendUnbarriered(thisObject->m_instanceTemplate.get());
+	visitor.append(thisObject->m_parentTemplate);
+	visitor.append(thisObject->m_prototypeProviderTemplate);
+	visitor.append(thisObject->m_prototypeTemplate);
+	visitor.append(thisObject->m_instanceTemplate);
 	visitor.append(thisObject->m_templateClassName);
 }
 

--- a/deps/jscshim/src/shim/GlobalObject.cpp
+++ b/deps/jscshim/src/shim/GlobalObject.cpp
@@ -96,6 +96,7 @@ void GlobalObject::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 	visitor.append(thisObject->m_shimExternalStructure);
 	thisObject->m_shimStackTraceStructure.visit(visitor);
 	thisObject->m_shimStackFrameStructure.visit(visitor);
+	thisObject->m_shimMessageStructure.visit(visitor);
 	thisObject->m_callSiteStructure.visit(visitor);
 	thisObject->m_callSitePrototype.visit(visitor);
 

--- a/deps/jscshim/src/shim/JSCStackTrace.h
+++ b/deps/jscshim/src/shim/JSCStackTrace.h
@@ -50,18 +50,18 @@ public:
 
 private:
 	JSC::VM& m_vm;
-	JSC::JSCell * m_callee;
+	JSC::Strong<JSC::JSCell> m_callee;
 
 	// May be null
 	JSC::ExecState * m_callFrame;
 	
 	// May be null
-	JSC::CodeBlock * m_codeBlock;
+	JSC::Strong<JSC::CodeBlock> m_codeBlock;
 	unsigned m_bytecodeOffset;
 
 	// Lazy-initialized
-	JSC::JSString * m_sourceURL;
-	JSC::JSString * m_functionName;
+	JSC::Strong<JSC::JSString> m_sourceURL;
+	JSC::Strong<JSC::JSString> m_functionName;
 
 	// m_wasmFunctionIndexOrName has meaning only when m_isWasmFrame is set
 	JSC::Wasm::IndexOrName m_wasmFunctionIndexOrName;
@@ -81,9 +81,9 @@ public:
 	JSCStackFrame(JSC::VM& vm, JSC::StackVisitor& visitor);
 	JSCStackFrame(JSC::VM& vm, const JSC::StackFrame& frame);
 
-	JSC::JSCell * callee() const { return m_callee; }
+	JSC::JSCell * callee() const { return m_callee.get(); }
 	JSC::ExecState * callFrame() const { return m_callFrame; }
-	JSC::CodeBlock * codeBlock() const { return m_codeBlock; }
+	JSC::CodeBlock * codeBlock() const { return m_codeBlock.get(); }
 	
 	intptr_t sourceID() const;
 	JSC::JSString * sourceURL();

--- a/deps/jscshim/src/shim/Message.cpp
+++ b/deps/jscshim/src/shim/Message.cpp
@@ -94,8 +94,10 @@ void Message::visitChildren(JSC::JSCell * cell, JSC::SlotVisitor& visitor)
 
 	Message * thisMessage = JSC::jsCast<Message *>(cell);
 	visitor.append(thisMessage->m_message);
+	visitor.append(thisMessage->m_resourceName);
 	visitor.append(thisMessage->m_sourceLine);
 	visitor.append(thisMessage->m_stackTrace);
+	visitor.append(thisMessage->m_sourceMapUrl);
 }
 
 // General flow here is based on JSC's appendSourceToError (ErrorInstance.cpp)

--- a/deps/jscshim/src/shim/Message.cpp
+++ b/deps/jscshim/src/shim/Message.cpp
@@ -95,7 +95,7 @@ void Message::visitChildren(JSC::JSCell * cell, JSC::SlotVisitor& visitor)
 	Message * thisMessage = JSC::jsCast<Message *>(cell);
 	visitor.append(thisMessage->m_message);
 	visitor.append(thisMessage->m_sourceLine);
-	visitor.appendUnbarriered(thisMessage->m_stackTrace.get());
+	visitor.append(thisMessage->m_stackTrace);
 }
 
 // General flow here is based on JSC's appendSourceToError (ErrorInstance.cpp)

--- a/deps/jscshim/src/shim/Object.cpp
+++ b/deps/jscshim/src/shim/Object.cpp
@@ -33,7 +33,7 @@ void Object::visitChildren(JSC::JSCell * cell, JSC::SlotVisitor& visitor)
 	Base::visitChildren(cell, visitor);
 
 	Object * thisObject = JSC::jsCast<Object *>(cell);
-	visitor.appendUnbarriered(thisObject->m_template.get());
+	visitor.append(thisObject->m_template);
 }
 
 JSC::CallType Object::getCallData(JSC::JSCell * cell, JSC::CallData& callData)

--- a/deps/jscshim/src/shim/ObjectTemplate.cpp
+++ b/deps/jscshim/src/shim/ObjectTemplate.cpp
@@ -31,6 +31,7 @@ void ObjectTemplate::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 
 	ObjectTemplate * thisTemplate = JSC::jsCast<ObjectTemplate *>(cell);
 	visitor.append(thisTemplate->m_objectStructure);
+	visitor.append(thisTemplate->m_constructor);
 }
 
 // TODO: Handle hidden prototypes

--- a/deps/jscshim/src/shim/PromiseResolver.cpp
+++ b/deps/jscshim/src/shim/PromiseResolver.cpp
@@ -44,7 +44,7 @@ void PromiseResolver::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor
 	Base::visitChildren(cell, visitor);
 
 	PromiseResolver * thisObject = JSC::jsCast<PromiseResolver *>(cell);
-	visitor.appendUnbarriered(thisObject->m_promise.get());
+	visitor.append(thisObject->m_promise);
 	visitor.append(thisObject->m_resolver);
 	visitor.append(thisObject->m_rejector);
 }

--- a/deps/jscshim/src/shim/StackTrace.cpp
+++ b/deps/jscshim/src/shim/StackTrace.cpp
@@ -47,7 +47,7 @@ void StackTrace::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 	for (auto& frame : thisObject->m_frames)
 	{
 		// Note: Using "append" causes a compilation error
-		visitor.appendUnbarriered(frame.get());
+		visitor.append(frame);
 	}
 }
 

--- a/deps/jscshim/src/shim/TemplateProperty.cpp
+++ b/deps/jscshim/src/shim/TemplateProperty.cpp
@@ -95,9 +95,9 @@ TemplateAccessorProperty::TemplateAccessorProperty(JSC::ExecState			* exec,
 	}
 }
 
-void TemplateAccessorProperty::visitChildren(JSC::SlotVisitor& visitor)
+void TemplateAccessorProperty::visitAggregate(JSC::SlotVisitor& visitor)
 {
-	TemplateProperty::visitChildren(visitor);
+	TemplateProperty::visitAggregate(visitor);
 
 	// Note: Using "append" causes a compilation error
 	visitor.append(m_getter);
@@ -149,9 +149,9 @@ TemplateAccessor::TemplateAccessor(JSC::ExecState				  * exec,
 	m_signature.setMayBeNull(vm, owner, signature);
 }
 
-void TemplateAccessor::visitChildren(JSC::SlotVisitor& visitor)
+void TemplateAccessor::visitAggregate(JSC::SlotVisitor& visitor)
 {
-	TemplateProperty::visitChildren(visitor);
+	TemplateProperty::visitAggregate(visitor);
 
 	// Note: Using "append" for m_signature causes a compilation error
 	visitor.append(m_data);

--- a/deps/jscshim/src/shim/TemplateProperty.cpp
+++ b/deps/jscshim/src/shim/TemplateProperty.cpp
@@ -100,8 +100,8 @@ void TemplateAccessorProperty::visitChildren(JSC::SlotVisitor& visitor)
 	TemplateProperty::visitChildren(visitor);
 
 	// Note: Using "append" causes a compilation error
-	visitor.appendUnbarriered(m_getter.get());
-	visitor.appendUnbarriered(m_setter.get());
+	visitor.append(m_getter);
+	visitor.append(m_setter);
 }
 
 JSC::JSValue TemplateAccessorProperty::instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype)
@@ -155,7 +155,7 @@ void TemplateAccessor::visitChildren(JSC::SlotVisitor& visitor)
 
 	// Note: Using "append" for m_signature causes a compilation error
 	visitor.append(m_data);
-	visitor.appendUnbarriered(m_signature.get());
+	visitor.append(m_signature);
 }
 
 JSC::JSValue TemplateAccessor::instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype)

--- a/deps/jscshim/src/shim/TemplateProperty.h
+++ b/deps/jscshim/src/shim/TemplateProperty.h
@@ -22,7 +22,7 @@ protected:
 	unsigned int m_attributes;
 
 public:
-	virtual void visitChildren(JSC::SlotVisitor& visitor)
+	virtual void visitAggregate(JSC::SlotVisitor& visitor)
 	{
 		// Note: Using "append" causes a compilation error
 		visitor.append(m_name);
@@ -37,7 +37,7 @@ protected:
 	TemplateProperty(JSC::ExecState * exec, JSC::JSCell * owner, JSC::JSCell * name, unsigned int attributes);
 };
 
-class TemplateValueProperty : public TemplateProperty
+class TemplateValueProperty final : public TemplateProperty
 {
 private:
 	JSC::WriteBarrier<JSC::Unknown> m_value;
@@ -49,9 +49,9 @@ public:
 						  unsigned int	 attributes, 
 						  JSC::JSValue	 value);
 
-	virtual void visitChildren(JSC::SlotVisitor& visitor) override
+	virtual void visitAggregate(JSC::SlotVisitor& visitor) override
 	{
-		TemplateProperty::visitChildren(visitor);
+		TemplateProperty::visitAggregate(visitor);
 
 		// Note: Using "append" causes a compilation error
 		visitor.append(m_value);
@@ -60,7 +60,7 @@ public:
 	virtual JSC::JSValue instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype) override;
 };
 
-class TemplateAccessorProperty : public TemplateProperty
+class TemplateAccessorProperty final : public TemplateProperty
 {
 private:
 	JSC::WriteBarrier<jscshim::FunctionTemplate> m_setter;
@@ -74,12 +74,12 @@ public:
 							 jscshim::FunctionTemplate	* getter, 
 							 jscshim::FunctionTemplate	* setter);
 
-	virtual void visitChildren(JSC::SlotVisitor& visitor) override;
+	virtual void visitAggregate(JSC::SlotVisitor& visitor) override;
 
 	virtual JSC::JSValue instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype) override;
 };
 
-class TemplateAccessor : public TemplateProperty
+class TemplateAccessor final : public TemplateProperty
 {
 private:
 	// TODO: Poison?
@@ -100,7 +100,7 @@ public:
 					 FunctionTemplate				* signature,
 					 bool							isSpecialDataProperty);
 
-	virtual void visitChildren(JSC::SlotVisitor& visitor) override;
+	virtual void visitAggregate(JSC::SlotVisitor& visitor) override;
 
 	virtual JSC::JSValue instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype) override;
 };

--- a/deps/jscshim/src/shim/TemplateProperty.h
+++ b/deps/jscshim/src/shim/TemplateProperty.h
@@ -25,7 +25,7 @@ public:
 	virtual void visitChildren(JSC::SlotVisitor& visitor)
 	{
 		// Note: Using "append" causes a compilation error
-		visitor.appendUnbarriered(m_name.get());
+		visitor.append(m_name);
 	}
 
 	virtual JSC::JSValue instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype) = 0;
@@ -54,7 +54,7 @@ public:
 		TemplateProperty::visitChildren(visitor);
 
 		// Note: Using "append" causes a compilation error
-		visitor.appendUnbarriered(m_value.get());
+		visitor.append(m_value);
 	}
 
 	virtual JSC::JSValue instantiate(JSC::VM& vm, JSC::ExecState * exec, bool isHiddenPrototype) override;


### PR DESCRIPTION
I found that node-jsc crashes when running `npm` command. After investigating, I found that some of the objects' fields are not marked correctly. Since these objects are allocated in the GC heap, we need to mark the fields in `visitChildren` function.

This series of patches are the first attempt of fixing these GC issues. Yeah, still some issues remain. For example interceptors' JSValue should be WriteBarrier and marked correctly. But this one attempts to fix the major issues.