### PR TITLE
Add destroy functions

### DIFF
--- a/deps/jscshim/jscshim.gyp
+++ b/deps/jscshim/jscshim.gyp
@@ -36,6 +36,7 @@
         ],
       }],
       ['OS in "linux"', {
+        'cflags': [ '-Wno-expansion-to-defined' ],
         'cflags_cc': [ '-fexceptions', '-std=gnu++14' ],
       }],
       ['OS in "mac ios"', {
@@ -123,6 +124,7 @@
         ]
       }],
       ['OS in "linux"', {
+        'cflags': [ '-Wno-expansion-to-defined' ],
         'cflags_cc': [ '-fexceptions', '-std=gnu++14' ],
         'link_settings': {
           'libraries': [ '-ldl' ],
@@ -363,6 +365,7 @@
         ]
       }],
       ['OS in "linux"', {
+        'cflags': [ '-Wno-expansion-to-defined' ],
         'cflags_cc': [ '-fexceptions', '-std=gnu++14' ],
         'link_settings': {
           'libraries': [ '-ldl' ],

--- a/deps/jscshim/src/shim/APIAccessor.h
+++ b/deps/jscshim/src/shim/APIAccessor.h
@@ -36,7 +36,7 @@ class FunctionTemplate;
  * There's also a comment in v8's https://github.com/v8/v8/commit/1da951ad0bd1a3c2247863060b87adeaef68fbd8
  * commit, saying "properties set by SetNativeDataProperty without kReadOnly flag can be replaced".
  * So basically, it seems that SetNativeDataProperty properties are "just" replaceables accessors. */
-class APIAccessor : public JSC::CustomAPIValue
+class APIAccessor final : public JSC::CustomAPIValue
 {
 private:
 	// TODO: Poison

--- a/deps/jscshim/src/shim/CallSite.h
+++ b/deps/jscshim/src/shim/CallSite.h
@@ -13,7 +13,7 @@
 namespace v8 { namespace jscshim
 {
 
-class CallSite : public JSC::JSNonFinalObject {
+class CallSite final : public JSC::JSNonFinalObject {
 public:
 	enum class Flags
 	{

--- a/deps/jscshim/src/shim/CallSitePrototype.h
+++ b/deps/jscshim/src/shim/CallSitePrototype.h
@@ -12,7 +12,7 @@
 namespace v8 { namespace jscshim
 {
 
-class CallSitePrototype : public JSC::JSNonFinalObject {
+class CallSitePrototype final : public JSC::JSNonFinalObject {
 public:
 	typedef JSNonFinalObject Base;
 

--- a/deps/jscshim/src/shim/External.cpp
+++ b/deps/jscshim/src/shim/External.cpp
@@ -11,6 +11,6 @@
 namespace v8 { namespace jscshim
 {
 
-const JSC::ClassInfo External::s_info = { "JSCShimAPIAccessor", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(External) };
+const JSC::ClassInfo External::s_info = { "JSCShimExternal", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(External) };
 
 }} // v8::jscshim

--- a/deps/jscshim/src/shim/External.h
+++ b/deps/jscshim/src/shim/External.h
@@ -5,18 +5,18 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSDestructibleObject.h>
+#include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 
 namespace v8 { namespace jscshim
 {
 
-class External : public JSC::JSDestructibleObject {
+class External : public JSC::JSNonFinalObject {
 private:
 	void * m_value;
 
 public:
-	typedef JSDestructibleObject Base;
+	using Base = JSNonFinalObject;
 
 	static External* create(JSC::VM& vm, JSC::ExecState * exec, JSC::Structure * structure, void * value)
 	{

--- a/deps/jscshim/src/shim/External.h
+++ b/deps/jscshim/src/shim/External.h
@@ -11,7 +11,7 @@
 namespace v8 { namespace jscshim
 {
 
-class External : public JSC::JSNonFinalObject {
+class External final : public JSC::JSNonFinalObject {
 private:
 	void * m_value;
 

--- a/deps/jscshim/src/shim/Function.h
+++ b/deps/jscshim/src/shim/Function.h
@@ -14,7 +14,7 @@
 namespace v8 { namespace jscshim
 {
 
-class Function : public JSC::InternalFunction
+class Function final : public JSC::InternalFunction
 {
 private:
 	JSC::WriteBarrier<FunctionTemplate> m_functionTemplate;

--- a/deps/jscshim/src/shim/GlobalObject.h
+++ b/deps/jscshim/src/shim/GlobalObject.h
@@ -16,7 +16,7 @@ namespace v8 { namespace jscshim
 class Isolate;
 class JSCStackTrace;
 
-class GlobalObject : public JSC::JSGlobalObject {
+class GlobalObject final : public JSC::JSGlobalObject {
 private:
 	// v8 reserves the first slot to itself, and node uses another one (in node_contextify.cc)
 	static int constexpr EMBEDDER_DATA_INITIAL_SIZE = 2;

--- a/deps/jscshim/src/shim/Message.h
+++ b/deps/jscshim/src/shim/Message.h
@@ -9,12 +9,12 @@
 #include "StackTrace.h"
 #include "JSCStackTrace.h"
 
-#include <JavaScriptCore/JSDestructibleObject.h>
+#include <JavaScriptCore/JSObject.h>
 
 namespace v8 { namespace jscshim
 {
 
-class Message : public JSC::JSDestructibleObject {
+class Message : public JSC::JSNonFinalObject {
 private:
 	JSC::WriteBarrier<JSC::JSString> m_message;
 	JSC::WriteBarrier<JSC::JSString> m_resourceName;
@@ -32,7 +32,7 @@ private:
 	int m_expressionStop;
 
 public:
-	typedef JSDestructibleObject Base;
+	using Base = JSC::JSNonFinalObject;
 
 	static Message * create(JSC::ExecState * exec, JSC::Structure * structure, JSC::Exception * exception, bool storeStackTrace)
 	{

--- a/deps/jscshim/src/shim/Message.h
+++ b/deps/jscshim/src/shim/Message.h
@@ -14,7 +14,7 @@
 namespace v8 { namespace jscshim
 {
 
-class Message : public JSC::JSNonFinalObject {
+class Message final : public JSC::JSNonFinalObject {
 private:
 	JSC::WriteBarrier<JSC::JSString> m_message;
 	JSC::WriteBarrier<JSC::JSString> m_resourceName;

--- a/deps/jscshim/src/shim/Object.cpp
+++ b/deps/jscshim/src/shim/Object.cpp
@@ -36,6 +36,11 @@ void Object::visitChildren(JSC::JSCell * cell, JSC::SlotVisitor& visitor)
 	visitor.appendUnbarriered(thisObject->m_template.get());
 }
 
+void Object::destroy(JSC::JSCell* cell)
+{
+	static_cast<Object*>(cell)->~Object();
+}
+
 JSC::CallType Object::getCallData(JSC::JSCell * cell, JSC::CallData& callData)
 {
 	Object * object = JSC::jsCast<Object*>(cell);

--- a/deps/jscshim/src/shim/Object.h
+++ b/deps/jscshim/src/shim/Object.h
@@ -65,6 +65,8 @@ protected:
 
 	static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
 
+	static void destroy(JSC::JSCell*);
+
 	static WTF::String className(const JSObject * object, JSC::VM& vm);
 };
 

--- a/deps/jscshim/src/shim/ObjectTemplate.cpp
+++ b/deps/jscshim/src/shim/ObjectTemplate.cpp
@@ -33,6 +33,11 @@ void ObjectTemplate::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 	visitor.append(thisTemplate->m_objectStructure);
 }
 
+void ObjectTemplate::destroy(JSC::JSCell* cell)
+{
+	static_cast<ObjectTemplate*>(cell)->~ObjectTemplate();
+}
+
 // TODO: Handle hidden prototypes
 Object * ObjectTemplate::makeNewObjectInstance(JSC::ExecState * exec, JSC::JSValue newTarget, Function * constructorInstance)
 {

--- a/deps/jscshim/src/shim/ObjectTemplate.h
+++ b/deps/jscshim/src/shim/ObjectTemplate.h
@@ -79,6 +79,7 @@ private:
 
 	void finishCreation(JSC::VM& vm, FunctionTemplate * constructor);
 	static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
+	static void destroy(JSC::JSCell*);
 
 	static JSC::EncodedJSValue JSC_HOST_CALL instanceFunctionCall(JSC::ExecState * exec);
 	static JSC::EncodedJSValue JSC_HOST_CALL instanceConstructorCall(JSC::ExecState * exec);

--- a/deps/jscshim/src/shim/ObjectTemplate.h
+++ b/deps/jscshim/src/shim/ObjectTemplate.h
@@ -16,7 +16,7 @@ namespace v8 { namespace jscshim
 class FunctionTemplate;
 class Object;
 
-class ObjectTemplate : public Template {
+class ObjectTemplate final : public Template {
 private:
 	friend class Object;
 	friend class ObjectWithInterceptors;

--- a/deps/jscshim/src/shim/ObjectWithInterceptors.cpp
+++ b/deps/jscshim/src/shim/ObjectWithInterceptors.cpp
@@ -462,6 +462,11 @@ uint32_t ObjectWithInterceptors::getEnumerableLength(JSC::ExecState * exec, JSC:
 	return Base::getEnumerableLength(exec, object);
 }
 
+void ObjectWithInterceptors::destroy(JSC::JSCell* cell)
+{
+	static_cast<ObjectWithInterceptors*>(cell)->~ObjectWithInterceptors();
+}
+
 template <typename InterceptorsType, typename JscPropertyNameType, typename v8PropertyNameType, typename DefaultHandlerType>
 bool ObjectWithInterceptors::performGetProperty(JSC::ExecState			   * exec,
 												InterceptorsType		   * interceptors,

--- a/deps/jscshim/src/shim/ObjectWithInterceptors.h
+++ b/deps/jscshim/src/shim/ObjectWithInterceptors.h
@@ -147,6 +147,8 @@ private:
 	static void getOwnNonIndexPropertyNames(JSC::JSObject *, JSC::ExecState *, JSC::PropertyNameArray&, JSC::EnumerationMode);
 
 	static uint32_t getEnumerableLength(JSC::ExecState * exec, JSC::JSObject * object);
+
+	static void destroy(JSC::JSCell*);
 	
 	// Taken from JSC's ProxyObject
 	static NO_RETURN_DUE_TO_CRASH void getStructurePropertyNames(JSC::JSObject *, JSC::ExecState *, JSC::PropertyNameArray&, JSC::EnumerationMode);

--- a/deps/jscshim/src/shim/ObjectWithInterceptors.h
+++ b/deps/jscshim/src/shim/ObjectWithInterceptors.h
@@ -13,7 +13,7 @@
 namespace v8 { namespace jscshim
 {
 
-class ObjectWithInterceptors : public jscshim::Object {
+class ObjectWithInterceptors final : public jscshim::Object {
 private:
 	/* A helper for creating and passing a local v8::PropertyCallbackInfo instance and a JSValue return value.
 	 * Regarding "this" and "holder" values, From v8's docs: 

--- a/deps/jscshim/src/shim/PromiseResolver.h
+++ b/deps/jscshim/src/shim/PromiseResolver.h
@@ -16,7 +16,7 @@ namespace v8 { namespace jscshim
 {
 
 // PromiseResolver is a shim for v8::PromiseResolver, which also acts the promise's executor (to get the resolve\reject callbacks)
-class PromiseResolver : public JSC::InternalFunction
+class PromiseResolver final : public JSC::InternalFunction
 {
 private:
 	JSC::WriteBarrier<JSC::JSPromise> m_promise;

--- a/deps/jscshim/src/shim/Script.h
+++ b/deps/jscshim/src/shim/Script.h
@@ -6,13 +6,13 @@
 #pragma once
 
 #include <v8.h>
-#include <JavaScriptCore/JSDestructibleObject.h>
+#include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSString.h>
 
 namespace v8 { namespace jscshim
 {
 
-class Script : public JSC::JSDestructibleObject {
+class Script : public JSC::JSNonFinalObject {
 private:
 	JSC::WriteBarrier<JSC::JSString> m_source;
 	JSC::WriteBarrier<JSC::JSString> m_resourceName;
@@ -21,7 +21,7 @@ private:
 	unsigned int m_resourceColumn;
 
 public:
-	typedef JSDestructibleObject Base;
+	using Base = JSC::JSNonFinalObject;
 
 	static Script * create(JSC::VM&		  vm, 
 						   JSC::Structure * structure, 

--- a/deps/jscshim/src/shim/Script.h
+++ b/deps/jscshim/src/shim/Script.h
@@ -12,7 +12,7 @@
 namespace v8 { namespace jscshim
 {
 
-class Script : public JSC::JSNonFinalObject {
+class Script final : public JSC::JSNonFinalObject {
 private:
 	JSC::WriteBarrier<JSC::JSString> m_source;
 	JSC::WriteBarrier<JSC::JSString> m_resourceName;

--- a/deps/jscshim/src/shim/StackFrame.h
+++ b/deps/jscshim/src/shim/StackFrame.h
@@ -14,7 +14,7 @@
 namespace v8 { namespace jscshim
 {
 
-class StackFrame : public JSC::JSNonFinalObject {
+class StackFrame final : public JSC::JSNonFinalObject {
 private:
 	/* m_line and m_column are one based
 	 * TODO: Use WTF::OrdinalNumber? */

--- a/deps/jscshim/src/shim/StackFrame.h
+++ b/deps/jscshim/src/shim/StackFrame.h
@@ -8,13 +8,13 @@
 #include <v8.h>
 #include "JSCStackTrace.h"
 
-#include <JavaScriptCore/JSDestructibleObject.h>
+#include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSString.h>
 
 namespace v8 { namespace jscshim
 {
 
-class StackFrame : public JSC::JSDestructibleObject {
+class StackFrame : public JSC::JSNonFinalObject {
 private:
 	/* m_line and m_column are one based
 	 * TODO: Use WTF::OrdinalNumber? */
@@ -27,7 +27,7 @@ private:
 	JSC::WriteBarrier<JSC::JSString> m_scriptName;
 
 public:
-	typedef JSDestructibleObject Base;
+	using Base = JSC::JSNonFinalObject;
 
 	static StackFrame* create(JSC::VM& vm, JSC::Structure* structure, JSCStackFrame& jsFrame)
 	{

--- a/deps/jscshim/src/shim/StackTrace.cpp
+++ b/deps/jscshim/src/shim/StackTrace.cpp
@@ -51,6 +51,11 @@ void StackTrace::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 	}
 }
 
+void StackTrace::destroy(JSC::JSCell* cell)
+{
+	static_cast<StackTrace*>(cell)->~StackTrace();
+}
+
 /* Note that at first I've allocated jscshim::StackFrame instances while walking the JSC stack. This failed 
  * because of an ASSERT in JSC's tryAllocateCellHelper, because of the JSC::DisallowGC used (which was there 
  * in JSC::Interpreter::getStackTrace). One possible solution is to use a JSC::GCDeferralContext, but besides needing

--- a/deps/jscshim/src/shim/StackTrace.h
+++ b/deps/jscshim/src/shim/StackTrace.h
@@ -77,6 +77,7 @@ private:
 	void finishCreation(JSC::VM& vm, JSC::ExecState * exec, JSCStackTrace& stackTrace);
 
 	static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
+	static void destroy(JSC::JSCell*);
 
 	// TODO: Rename as an overload to finishCreation?
 	void captureCurrentStackTrace(JSC::VM& vm, JSC::ExecState * exec, size_t frameLimit);

--- a/deps/jscshim/src/shim/StackTrace.h
+++ b/deps/jscshim/src/shim/StackTrace.h
@@ -17,7 +17,7 @@
 namespace v8 { namespace jscshim
 {
 
-class StackTrace : public JSC::JSDestructibleObject {
+class StackTrace final : public JSC::JSDestructibleObject {
 private:
 	WTF::Vector<JSC::WriteBarrier<StackFrame>> m_frames;
 

--- a/deps/jscshim/src/shim/Template.cpp
+++ b/deps/jscshim/src/shim/Template.cpp
@@ -171,6 +171,11 @@ void Template::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor)
 	}	
 }
 
+void Template::destroy(JSC::JSCell* cell)
+{
+	static_cast<Template*>(cell)->~Template();
+}
+
 void Template::ensureNotInstantiated(const char * v8Caller) const
 {
 	if (m_instantiated)

--- a/deps/jscshim/src/shim/Template.h
+++ b/deps/jscshim/src/shim/Template.h
@@ -74,6 +74,7 @@ protected:
 	void finishCreation(JSC::VM& vm, const WTF::String& name);
 
 	static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
+	static void destroy(JSC::JSCell*);
 
 	void applyPropertiesToInstance(JSC::ExecState * exec, JSC::JSObject * instance);
 

--- a/deps/jscshim/src/v8WeakWrapper.cpp
+++ b/deps/jscshim/src/v8WeakWrapper.cpp
@@ -16,7 +16,7 @@
 namespace
 {
 
-class PersistentBaseWeakHandleOwner : public JSC::WeakHandleOwner
+class PersistentBaseWeakHandleOwner final : public JSC::WeakHandleOwner
 {
 public:
 	PersistentBaseWeakHandleOwner() {}


### PR DESCRIPTION
If we want to call the destructor of the GC-managed objects, we need to
(1) inherit JSDestructibleObject and (2) define own destroy function.

This patch implements destroy functions so that destructors are called correctly.
Also, we change some of JSDestructibleObject to JSNonFinalObject if they do not
require calling destructors.