### PR TITLE
Connect Isolate to JSC::VM by inheriting JSC::VM::ClientData

### DIFF
--- a/deps/jscshim/jscshim.gyp
+++ b/deps/jscshim/jscshim.gyp
@@ -222,6 +222,7 @@
       'src/shim/FunctionTemplate.h',
       'src/shim/GlobalObject.cpp',
       'src/shim/GlobalObject.h',
+      'src/shim/GlobalObjectInlines.h',
       'src/shim/helpers.h',
       'src/shim/InterceptorInfo.h',
       'src/shim/Isolate.cpp',

--- a/deps/jscshim/src/shim/Function.h
+++ b/deps/jscshim/src/shim/Function.h
@@ -26,10 +26,7 @@ public:
 	template<typename CellType>
 	static JSC::IsoSubspace * subspaceFor(JSC::VM& vm)
 	{
-		jscshim::Isolate * currentIsolate = jscshim::Isolate::GetCurrent();
-		RELEASE_ASSERT(&currentIsolate->VM() == &vm);
-
-		return currentIsolate->FunctionSpace();
+		return static_cast<jscshim::Isolate*>(vm.clientData)->FunctionSpace();
 	}
 
 	static Function* create(JSC::VM& vm, JSC::Structure* structure, FunctionTemplate * functionTemplate, JSC::JSString * name, int length)

--- a/deps/jscshim/src/shim/FunctionTemplate.cpp
+++ b/deps/jscshim/src/shim/FunctionTemplate.cpp
@@ -81,7 +81,7 @@ bool FunctionTemplate::isTemplateFor(jscshim::Object * object)
 
 bool FunctionTemplate::isTemplateFor(JSC::JSValue value)
 {
-	jscshim::Object * object = JSC::jsDynamicCast<jscshim::Object *>(m_isolate->VM(), value);
+	jscshim::Object * object = JSC::jsDynamicCast<jscshim::Object *>(*vm(), value);
 	if (nullptr == object)
 	{
 		return false;

--- a/deps/jscshim/src/shim/FunctionTemplate.h
+++ b/deps/jscshim/src/shim/FunctionTemplate.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "v8.h"
+#include "GlobalObjectInlines.h"
 #include "Template.h"
 #include "ObjectTemplate.h"
 #include "helpers.h"
@@ -62,10 +63,7 @@ public:
 	template<typename CellType>
 	static JSC::IsoSubspace * subspaceFor(JSC::VM& vm)
 	{
-		jscshim::Isolate * currentIsolate = jscshim::Isolate::GetCurrent();
-		RELEASE_ASSERT(&currentIsolate->VM() == &vm);
-
-		return currentIsolate->FunctionTemplateSpace();
+		return static_cast<jscshim::Isolate*>(vm.clientData)->FunctionTemplateSpace();
 	}
 
 	static FunctionTemplate* create(JSC::VM&			 vm, 
@@ -76,11 +74,8 @@ public:
 									JSC::JSValue		 data, 
 									FunctionTemplate	 * signature)
 	{
-		GlobalObject * global = GetGlobalObject(exec);
-
 		FunctionTemplate* cell = new (NotNull, JSC::allocateCell<FunctionTemplate>(vm.heap)) FunctionTemplate(vm, 
 																											  structure, 
-																											  global->isolate(), 
 																											  callback, 
 																											  length);
 		cell->finishCreation(vm, length, data, signature);
@@ -130,9 +125,8 @@ private:
 	 * to return ConstructType::None) */
 	FunctionTemplate(JSC::VM&			  vm, 
 					 JSC::Structure		  * structure,
-					 Isolate			  * isolate, 
 					 v8::FunctionCallback callback, 
-					 int				  length) : Base(vm, structure, isolate, functionCall, JSC::callHostFunctionAsConstructor),
+					 int				  length) : Base(vm, structure, functionCall, JSC::callHostFunctionAsConstructor),
 		m_length(length),
 		m_flags(static_cast<unsigned char>(TemplateFlags::None))
 	{

--- a/deps/jscshim/src/shim/GlobalObject.cpp
+++ b/deps/jscshim/src/shim/GlobalObject.cpp
@@ -70,9 +70,9 @@ const JSC::GlobalObjectMethodTable GlobalObject::globalObjectMethodTable = {
 	nullptr  // instantiateStreaming
 };
 
-GlobalObject * GlobalObject::create(JSC::VM& vm, JSC::Structure * structure, Isolate * isolate, int globalInternalFieldCount)
+GlobalObject * GlobalObject::create(JSC::VM& vm, JSC::Structure * structure, int globalInternalFieldCount)
 {
-	GlobalObject * global = new (NotNull, JSC::allocateCell<GlobalObject>(vm.heap)) GlobalObject(vm, structure, isolate, globalInternalFieldCount);
+	GlobalObject * global = new (NotNull, JSC::allocateCell<GlobalObject>(vm.heap)) GlobalObject(vm, structure, globalInternalFieldCount);
 	global->finishCreation(vm);
 	return global;
 }
@@ -126,8 +126,7 @@ void GlobalObject::setAlignedPointerInEmbedderData(int index, void * value)
 	m_contextEmbedderData.SetAlignedPointer(index, value);
 }
 
-GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure * structure, Isolate * isolate, int globalInternalFieldCount) : JSGlobalObject(vm, structure, &globalObjectMethodTable),
-	m_isolate(isolate),
+GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure * structure, int globalInternalFieldCount) : JSGlobalObject(vm, structure, &globalObjectMethodTable),
 	m_contextEmbedderData(EMBEDDER_DATA_INITIAL_SIZE),
 	m_globalInternalFields(globalInternalFieldCount)
 {
@@ -229,9 +228,10 @@ void GlobalObject::setupObjectProtoAccessor(JSC::VM& vm)
 
 void GlobalObject::promiseRejectionTracker(JSGlobalObject * jsGlobalObject, JSC::ExecState* exec, JSC::JSPromise* promise, JSC::JSPromiseRejectionOperation operation)
 {
+	JSC::VM& vm = exec->vm();
 	GlobalObject * self = JSC::jsCast<GlobalObject *>(jsGlobalObject);
 
-	v8::PromiseRejectCallback userCallback = self->m_isolate->PromiseRejectCallback();
+	v8::PromiseRejectCallback userCallback = GetIsolate(vm)->PromiseRejectCallback();
 	if (nullptr == userCallback)
 	{
 		return;

--- a/deps/jscshim/src/shim/GlobalObject.h
+++ b/deps/jscshim/src/shim/GlobalObject.h
@@ -23,8 +23,6 @@ private:
 
 	template<typename T> using Initializer = typename JSC::LazyProperty<GlobalObject, T>::Initializer;
 
-	Isolate * m_isolate;
-
 	/* In jscshim, a v8::Context is actually just the global object. But in v8 they're different
 	 * entities. They also have different internal\embedded fields: Contexts have auto-growing 
 	 * "embedder" data, while global objects might have internal fields (if they were created
@@ -60,7 +58,7 @@ private:
 public:
 	typedef JSC::JSGlobalObject Base;
 
-	static GlobalObject * create(JSC::VM& vm, JSC::Structure * structure, Isolate * isolate, int globalInternalFieldCount);
+	static GlobalObject * create(JSC::VM& vm, JSC::Structure * structure, int globalInternalFieldCount);
 
 	static const bool needsDestruction = true;
 
@@ -91,7 +89,7 @@ public:
 
 	JSC::JSValue objectProtoToString() const { return m_objectProtoToString.get(); }
 	
-	Isolate * isolate() const { return m_isolate; }
+	Isolate * isolate() const;
 	JSC::ExecState * v8ContextExec() const { return m_contextExec; }
 
 	EmbeddedFieldsContainer<false>& globalInternalFields() { return m_globalInternalFields; }
@@ -105,7 +103,7 @@ public:
 	void setAlignedPointerInEmbedderData(int index, void * value);
 
 private:
-	GlobalObject(JSC::VM& vm, JSC::Structure * structure, Isolate * isolate, int globalInternalFieldCount);
+	GlobalObject(JSC::VM& vm, JSC::Structure * structure, int globalInternalFieldCount);
 
 	~GlobalObject() {}
 

--- a/deps/jscshim/src/shim/GlobalObjectInlines.h
+++ b/deps/jscshim/src/shim/GlobalObjectInlines.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Yusuke Suzuki <yusukesuzuki@slowstart.org>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GlobalObject.h"
+#include "Isolate.h"
+
+namespace v8 { namespace jscshim {
+
+inline Isolate* GlobalObject::isolate() const
+{
+	return static_cast<Isolate*>(vm().clientData);
+}
+
+} } // v8::jscshim

--- a/deps/jscshim/src/shim/Isolate.cpp
+++ b/deps/jscshim/src/shim/Isolate.cpp
@@ -244,7 +244,6 @@ jscshim::GlobalObject * Isolate::GetCurrentGlobalOrDefault()
 		JSC::JSLockHolder locker(m_vm.get());
 		m_defaultGlobal = jscshim::GlobalObject::create(*m_vm,
 														jscshim::GlobalObject::createStructure(*m_vm, JSC::jsNull()),
-														this,
 														0);
 		JSC::gcProtect(m_defaultGlobal);
 	}

--- a/deps/jscshim/src/shim/Isolate.h
+++ b/deps/jscshim/src/shim/Isolate.h
@@ -19,8 +19,7 @@ namespace v8 { namespace jscshim
 {
 class GlobalObject;
 
-class Isolate
-{
+class Isolate : public JSC::VM::ClientData {
 public:
 	class CurrentContextScope
 	{
@@ -58,7 +57,7 @@ private:
 	static constexpr uint32_t ISOLATE_DATA_SLOTS = 4;
 
 private:
-	JSC::VM * m_vm;
+	RefPtr<JSC::VM> m_vm;
 	JSC::IsoSubspace m_functionSpace;
 	JSC::IsoSubspace m_functionTemplateSpace;
 	JSC::IsoSubspace m_objectTemplateSpace;
@@ -238,7 +237,7 @@ private:
 	friend class ShimExceptionScope;
 
 	// Construction/Destruction should go through New/Dispose
-	explicit Isolate(JSC::VM * vm, v8::ArrayBuffer::Allocator * arrayBufferAllocator);
+	explicit Isolate(RefPtr<JSC::VM>&& vm, v8::ArrayBuffer::Allocator * arrayBufferAllocator);
 	~Isolate();
 
 	void ReportMessageToListenersIfNeeded(jscshim::Message * message, JSC::Exception * exception);

--- a/deps/jscshim/src/shim/Message.cpp
+++ b/deps/jscshim/src/shim/Message.cpp
@@ -5,6 +5,8 @@
 
 #include "config.h"
 #include "Message.h"
+
+#include "GlobalObjectInlines.h"
 #include "helpers.h"
 
 #include <JavaScriptCore/Exception.h>

--- a/deps/jscshim/src/shim/ObjectTemplate.h
+++ b/deps/jscshim/src/shim/ObjectTemplate.h
@@ -33,17 +33,12 @@ public:
 	template<typename CellType>
 	static JSC::IsoSubspace * subspaceFor(JSC::VM& vm)
 	{
-		jscshim::Isolate * currentIsolate = jscshim::Isolate::GetCurrent();
-		RELEASE_ASSERT(&currentIsolate->VM() == &vm);
-
-		return currentIsolate->ObjectTemplateSpace();
+		return static_cast<jscshim::Isolate*>(vm.clientData)->ObjectTemplateSpace();
 	}
 
 	static ObjectTemplate* create(JSC::VM& vm, JSC::Structure * structure, JSC::ExecState * exec, FunctionTemplate * constructor)
 	{
-		GlobalObject * global = GetGlobalObject(exec);
-
-		ObjectTemplate* newTemplate = new (NotNull, JSC::allocateCell<ObjectTemplate>(vm.heap)) ObjectTemplate(vm, structure, global->isolate());
+		ObjectTemplate* newTemplate = new (NotNull, JSC::allocateCell<ObjectTemplate>(vm.heap)) ObjectTemplate(vm, structure);
 		newTemplate->finishCreation(vm, constructor);
 		return newTemplate;
 	}
@@ -70,7 +65,7 @@ public:
 
 private:
 	// TODO: Function pointers
-	ObjectTemplate(JSC::VM& vm, JSC::Structure * structure, Isolate * isolate) : Base(vm, structure, isolate, DummyCallback, DummyCallback),
+	ObjectTemplate(JSC::VM& vm, JSC::Structure * structure) : Base(vm, structure, DummyCallback, DummyCallback),
 		m_internalFieldCount(0)
 	{
 	}

--- a/deps/jscshim/src/shim/PromiseResolver.h
+++ b/deps/jscshim/src/shim/PromiseResolver.h
@@ -29,10 +29,7 @@ public:
 	template<typename CellType>
 	static JSC::IsoSubspace * subspaceFor(JSC::VM& vm)
 	{
-		jscshim::Isolate * currentIsolate = jscshim::Isolate::GetCurrent();
-		RELEASE_ASSERT(&currentIsolate->VM() == &vm);
-
-		return currentIsolate->PromiseResolverSpace();
+		return static_cast<jscshim::Isolate*>(vm.clientData)->PromiseResolverSpace();
 	}
 
 	static PromiseResolver* create(JSC::VM& vm, JSC::Structure* structure, JSC::ExecState * exec)

--- a/deps/jscshim/src/shim/Template.cpp
+++ b/deps/jscshim/src/shim/Template.cpp
@@ -146,7 +146,7 @@ JSC::JSValue Template::forwardCallToCallback(JSC::ExecState		  * exec,
 													 Local<Value>(newTarget),
 													 isConstructorCall,
 													 Local<Value>(m_callAsFunctionCallbackData.get()),
-													 reinterpret_cast<v8::Isolate *>(m_isolate),
+													 reinterpret_cast<v8::Isolate *>(GetIsolate(exec->vm())),
 													 &returnValue);
 	m_callAsFunctionCallback(callbackInfo);
 

--- a/deps/jscshim/src/shim/Template.h
+++ b/deps/jscshim/src/shim/Template.h
@@ -23,7 +23,6 @@ class FunctionTemplate;
 
 class Template : public JSC::InternalFunction {
 protected:
-	Isolate * m_isolate;
 	bool m_forceFunctionInstantiation;
 
 	v8::FunctionCallback m_callAsFunctionCallback;
@@ -61,10 +60,8 @@ public:
 protected:
 	Template(JSC::VM&			 vm,
 			 JSC::Structure		 * structure,
-			 Isolate			 * isolate,
 			 JSC::NativeFunction functionForCall,
 			 JSC::NativeFunction functionForConstruct) : Base(vm, structure, functionForCall, functionForConstruct),
-		m_isolate(isolate),
 		m_forceFunctionInstantiation(false),
 		m_callAsFunctionCallback(nullptr),
 		m_instantiated(false)

--- a/deps/jscshim/src/shim/exceptions.h
+++ b/deps/jscshim/src/shim/exceptions.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "Isolate.h"
-#include "GlobalObject.h"
+#include "GlobalObjectInlines.h"
 
 #include <JavaScriptCore/ThrowScope.h>
 #include <JavaScriptCore/CatchScope.h>

--- a/deps/jscshim/src/shim/helpers.h
+++ b/deps/jscshim/src/shim/helpers.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "Isolate.h"
-#include "GlobalObject.h"
+#include "GlobalObjectInlines.h"
 #include "exceptions.h"
 
 #include <JavaScriptCore/CodeBlock.h>
@@ -79,6 +79,11 @@ inline JSC::ExecState * GetExecStateForV8Context(v8::Context * context)
 inline JSC::VM& GetCurrentVM()
 {
 	return reinterpret_cast<jscshim::Isolate *>(v8::Isolate::GetCurrent())->VM();
+}
+
+inline jscshim::Isolate* GetIsolate(JSC::VM& vm)
+{
+	return static_cast<jscshim::Isolate*>(vm.clientData);
 }
 
 inline JSC::ExecState * GetCurrentExecState()

--- a/deps/jscshim/src/v8Context.cpp
+++ b/deps/jscshim/src/v8Context.cpp
@@ -7,7 +7,7 @@
 #include "v8.h"
 
 #include "shim/helpers.h"
-#include "shim/GlobalObject.h"
+#include "shim/GlobalObjectInlines.h"
 #include "shim/FunctionTemplate.h"
 #include "shim/Object.h"
 #include "shim/ObjectTemplate.h"
@@ -76,14 +76,12 @@ Local<Context> Context::New(Isolate* isolate,
 
 		globalObject = jscshim::GlobalObject::create(vm,
 													 jscshim::GlobalObject::createStructure(vm, globalObjectPrototype),
-													 jscIsolate,
 													 globalObjectTemplate->internalFieldCount());
 	}
 	else
 	{
 		globalObject = jscshim::GlobalObject::create(vm,
 													 jscshim::GlobalObject::createStructure(vm, JSC::jsNull()),
-													 jscIsolate,
 													 0);
 	}
 

--- a/deps/jscshim/src/v8Promise.cpp
+++ b/deps/jscshim/src/v8Promise.cpp
@@ -97,7 +97,7 @@ bool Promise::HasHandler()
 {
 	JSC::JSPromise * thisPromise = GET_JSC_THIS_PROMISE();
 	JSC::VM& vm = *thisPromise->vm();
-	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::Isolate::GetCurrent());
+	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::GetIsolate(vm));
 
 	return thisPromise->isHandled(vm);
 }
@@ -106,7 +106,7 @@ Local<Value> Promise::Result()
 {
 	JSC::JSPromise * thisPromise = GET_JSC_THIS_PROMISE();
 	JSC::VM& vm = *thisPromise->vm();
-	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::Isolate::GetCurrent());
+	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::GetIsolate(vm));
 
 	jscshim::ApiCheck(JSC::JSPromise::Status::Pending != thisPromise->status(vm), 
 					  "v8_Promise_Result",
@@ -119,7 +119,7 @@ Promise::PromiseState Promise::State()
 {
 	JSC::JSPromise * thisPromise = GET_JSC_THIS_PROMISE();
 	JSC::VM& vm = *thisPromise->vm();
-	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::Isolate::GetCurrent());
+	DECLARE_SHIM_EXCEPTION_SCOPE(jscshim::GetIsolate(vm));
 
 	JSC::JSPromise::Status state = thisPromise->status(vm);
 


### PR DESCRIPTION
We can directly put Isolate into JSC::VM. JSC::VM has `clientData` field, and we can put client data into this field. By using this, we can set bidirectional links between Isolate and JSC::VM, which is super useful since we can just use JSC::VM as much as possible. And once Isolate is needed, we can retrieve it from JSC::VM.